### PR TITLE
Stop interferention of background

### DIFF
--- a/sass/custom/_styles.scss
+++ b/sass/custom/_styles.scss
@@ -17,6 +17,7 @@ a:visited, #content .blog-index article h1 a:hover {
 html {
   //background: #262C33 url("/images/line-tile.png");
   background-image: url("/images/stripe.png");
+  background-attachment: fixed;
 }
 
 body {


### PR DESCRIPTION
The striped background of the website can appear to 'flicker' while scrolling through the page. This is likely caused by interferention.

By fixing the background in place, this is prevented.